### PR TITLE
Change hostname and view networking info

### DIFF
--- a/src/src/args.rs
+++ b/src/src/args.rs
@@ -24,6 +24,9 @@ pub enum Operation {
 
     #[command(bin_name = "axctl", name = "net", aliases = ["network"], about = "Basic networking commands")]
     Network(SimpleNetworking),
+
+    #[command(bin_name = "axctl", name = "device-info", aliases = ["info"], about = "Display device information")]
+    DeviceInfo,
 }
 
 #[derive(Default, Debug, Clone, Parser)]
@@ -63,3 +66,6 @@ pub struct SimpleNetworking {
     #[command(subcommand)]
     pub action: NetworkOperation,
 }
+
+#[derive(Debug, Clone, Parser)]
+pub struct DeviceInfo;

--- a/src/src/args.rs
+++ b/src/src/args.rs
@@ -18,6 +18,12 @@ pub enum Operation {
 
     #[command(bin_name = "axctl", name = "toggle-boot-menu", aliases = ["boot-menu"], about = "Toggle the boot menu on or off")]
     ToggleBootMenu,
+
+    #[command(bin_name = "axctl", name = "change-hostname", aliases = ["hostname"], about = "Change the device hostname")]
+    ChangeHostName(ChangeHostName),
+
+    #[command(bin_name = "axctl", name = "net", aliases = ["network"], about = "Basic networking commands")]
+    Network(SimpleNetworking),
 }
 
 #[derive(Default, Debug, Clone, Parser)]
@@ -34,3 +40,26 @@ pub struct ToggleBootMenuArgs {
     pub enable: Option<bool>,
 }
 
+#[derive(Default, Debug, Clone, Parser)]
+pub struct ChangeHostName {
+    #[arg(help = "Change the hostname")]
+    pub hostname: String,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum NetworkOperation {
+    #[command(about = "Show IP and interface status")]
+    Status,
+
+    #[command(about = "Restart networking services")]
+    Restart,
+
+    #[command(about = "Run a basic network diagnostic")]
+    Test,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct SimpleNetworking {
+    #[command(subcommand)]
+    pub action: NetworkOperation,
+}

--- a/src/src/main.rs
+++ b/src/src/main.rs
@@ -32,6 +32,9 @@ async fn main() {
         Some(Operation::Network(args)) => {
             operations::networking(&args)
         }
+        Some(Operation::DeviceInfo) => {
+            operations::device_info()
+        }
         None => {
             println!("No subcommand provided. Use --help for more information.");
         }

--- a/src/src/main.rs
+++ b/src/src/main.rs
@@ -25,6 +25,13 @@ async fn main() {
         Some(Operation::ToggleBootMenu) => {
             operations::grub_menu_toggle().await
         }
+        Some(Operation::ChangeHostName(args)) => {
+            // println!("{}", args.hostname); // debug
+            operations::change_hostname(&args.hostname)
+        }
+        Some(Operation::Network(args)) => {
+            operations::networking(&args)
+        }
         None => {
             println!("No subcommand provided. Use --help for more information.");
         }

--- a/src/src/operations/change_hostname.rs
+++ b/src/src/operations/change_hostname.rs
@@ -1,0 +1,65 @@
+pub fn change_hostname(hostname: &str) {
+    let output = std::process::Command::new("sudo")
+        .arg("hostnamectl")
+        .arg("set-hostname")
+        .arg(hostname)
+        .output();
+
+    match output {
+        Ok(output) if output.status.success() => {
+            println!("Hostname changed to: {}", hostname);
+        }
+        Ok(output) => {
+            eprintln!(
+                "Failed to change hostname. Error: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return;
+        }
+        Err(e) => {
+            eprintln!("Error running hostnamectl: {}", e);
+            return;
+        }
+    }
+
+    let hosts_path = "/etc/hosts";
+    let hosts_content = match std::fs::read_to_string(hosts_path) {
+        Ok(content) => content,
+        Err(e) => {
+            eprintln!("Failed to read {}: {}", hosts_path, e);
+            return;
+        }
+    };
+
+    let old_hostname = match get_current_hostname() {
+        Ok(name) => name,
+        Err(e) => {
+            eprintln!("Failed to get current hostname: {}", e);
+            return;
+        }
+    };
+
+    let updated_hosts = hosts_content.replace(
+        &format!("127.0.1.1\t{}", old_hostname),
+        &format!("127.0.1.1\t{}", hostname),
+    );
+
+    if let Err(e) = std::fs::write(hosts_path, updated_hosts) {
+        eprintln!("Failed to write to {}: {}", hosts_path, e);
+        return;
+    }
+
+    println!("Updated /etc/hosts with new hostname.");
+}
+
+fn get_current_hostname() -> Result<String, String> {
+    let output = std::process::Command::new("hostname")
+        .output()
+        .map_err(|e| format!("Failed to run hostname command: {}", e))?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(String::from_utf8_lossy(&output.stderr).to_string())
+    }
+}

--- a/src/src/operations/device_info.rs
+++ b/src/src/operations/device_info.rs
@@ -1,0 +1,95 @@
+pub fn device_info() {
+    use std::process::Command;
+
+    println!("==========[ System Info ]==========");
+
+    let os = Command::new("uname")
+        .arg("-o")
+        .output()
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
+        .unwrap_or_else(|_| "?".into());
+
+    let kernel = Command::new("uname")
+        .arg("-r")
+        .output()
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
+        .unwrap_or_else(|_| "?".into());
+
+    let uptime = Command::new("uptime")
+        .arg("-p")
+        .output()
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
+        .unwrap_or_else(|_| "?".into());
+
+    let memory_raw = Command::new("free")
+        .arg("-h")
+        .output()
+        .expect("Failed to fetch memory info.");
+    let memory_output = String::from_utf8_lossy(&memory_raw.stdout);
+    let total_memory = memory_output
+        .lines()
+        .find(|line| line.starts_with("Mem:"))
+        .and_then(|line| line.split_whitespace().nth(1))
+        .unwrap_or("?");
+
+    let cpu_raw = Command::new("lscpu")
+        .output()
+        .expect("Failed to fetch CPU info.");
+    let cpu_output = String::from_utf8_lossy(&cpu_raw.stdout);
+    let cpu_model = cpu_output
+        .lines()
+        .find(|line| line.starts_with("Model name"))
+        .and_then(|line| line.split(':').nth(1))
+        .map(str::trim)
+        .unwrap_or("?");
+
+    let disk_raw = Command::new("df")
+        .arg("-h")
+        .output()
+        .expect("Failed to fetch disk info.");
+    let disk_output = String::from_utf8_lossy(&disk_raw.stdout);
+    let (disk_used, disk_total): (String, String) = disk_output
+        .lines()
+        .find(|line| line.contains(" /"))
+        .map(|line| {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            (
+                parts.get(2).unwrap_or(&"?").to_string(),
+                parts.get(1).unwrap_or(&"?").to_string(),
+            )
+        })
+        .unwrap_or(("?".into(), "?".into()));
+
+    let hostname = Command::new("hostname")
+        .output()
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
+        .unwrap_or_else(|_| "?".into());
+
+    let pkg_mgr = Command::new("pacman").arg("-V").output()
+    .map(|out| {
+        if out.status.success() {
+            "pacman (Arch-based)"
+        } else {
+            Command::new("dpkg").arg("-l").output()
+                .map(|out| {
+                    if out.status.success() {
+                        "dpkg (Debian-based)"
+                    } else {
+                        "Unknown"
+                    }
+                })
+                .unwrap_or("Unknown")
+        }
+    })
+    .unwrap_or("Unknown");
+
+
+    println!("Hostname       : {}", hostname);
+    println!("OS             : {}", os);
+    println!("Kernel         : {}", kernel);
+    println!("Uptime         : {}", uptime);
+    println!("CPU            : {}", cpu_model);
+    println!("RAM (total)    : {}", total_memory);
+    println!("Disk (/ used)  : {}/{}", disk_used, disk_total);
+    println!("Package Manager: {}", pkg_mgr);
+}

--- a/src/src/operations/mod.rs
+++ b/src/src/operations/mod.rs
@@ -1,5 +1,9 @@
 mod grub_menu_toggle;
 mod splash_screen_toggle;
+mod change_hostname;
+mod networking;
 
 pub use grub_menu_toggle::grub_menu_toggle;
 pub use splash_screen_toggle::splash_screen_toggle;
+pub use change_hostname::change_hostname;
+pub use networking::networking;

--- a/src/src/operations/mod.rs
+++ b/src/src/operations/mod.rs
@@ -2,8 +2,10 @@ mod grub_menu_toggle;
 mod splash_screen_toggle;
 mod change_hostname;
 mod networking;
+mod device_info;
 
 pub use grub_menu_toggle::grub_menu_toggle;
 pub use splash_screen_toggle::splash_screen_toggle;
 pub use change_hostname::change_hostname;
 pub use networking::networking;
+pub use device_info::device_info;

--- a/src/src/operations/networking.rs
+++ b/src/src/operations/networking.rs
@@ -1,0 +1,175 @@
+use crate::args::SimpleNetworking;
+use crate::args::NetworkOperation;
+use std::process::{Command, exit};
+
+pub fn networking(args: &SimpleNetworking) {
+    match &args.action {
+        NetworkOperation::Status => {
+            network_status();
+        }
+        NetworkOperation::Restart => {
+            network_restart();
+        }
+        NetworkOperation::Test => {
+            network_test();
+        }
+    }
+}
+
+fn network_status() {
+    println!("==================== Network Status ====================");
+
+    // interface details
+    println!("\n--- Network Interfaces ---");
+    let ip_output = Command::new("ip")
+        .arg("a")
+        .output()
+        .expect("Failed to run 'ip a'");
+
+    if !ip_output.status.success() {
+        eprintln!("Error running 'ip a': {}", String::from_utf8_lossy(&ip_output.stderr));
+        return;
+    }
+    println!("{}", String::from_utf8_lossy(&ip_output.stdout));
+
+    // interface status
+    println!("\n--- Interface Status ---");
+    let link_output = Command::new("ip")
+        .arg("link")
+        .output()
+        .expect("Failed to run 'ip link'");
+
+    if !link_output.status.success() {
+        eprintln!("Error running 'ip link': {}", String::from_utf8_lossy(&link_output.stderr));
+        return;
+    }
+    println!("{}", String::from_utf8_lossy(&link_output.stdout));
+
+    // our routing table
+    println!("\n--- Routing Table ---");
+    let route_output = Command::new("ip")
+        .arg("route")
+        .output()
+        .expect("Failed to run 'ip route'");
+
+    if !route_output.status.success() {
+        eprintln!("Error running 'ip route': {}", String::from_utf8_lossy(&route_output.stderr));
+        return;
+    }
+    println!("{}", String::from_utf8_lossy(&route_output.stdout));
+
+    // dns
+    println!("\n--- DNS Configuration ---");
+    let dns_output = std::fs::read_to_string("/etc/resolv.conf")
+        .unwrap_or_else(|_| "Unable to read /etc/resolv.conf".to_string());
+    println!("{}", dns_output);
+
+    println!("\n--- Active Connections ---");
+    let netstat_output = Command::new("ss")
+        .arg("-tuln")
+        .output()
+        .expect("Failed to run 'ss'");
+
+    if !netstat_output.status.success() {
+        eprintln!("Error running 'ss': {}", String::from_utf8_lossy(&netstat_output.stderr));
+        return;
+    }
+    println!("{}", String::from_utf8_lossy(&netstat_output.stdout));
+
+    // ping
+    println!("\n--- Internet Connectivity Test ---");
+    let ping_output = Command::new("ping")
+        .arg("-c")
+        .arg("4")
+        .arg("8.8.8.8")
+        .output()
+        .expect("Failed to run 'ping'");
+
+    if !ping_output.status.success() {
+        eprintln!("Error pinging: {}", String::from_utf8_lossy(&ping_output.stderr));
+        return;
+    }
+    println!("{}", String::from_utf8_lossy(&ping_output.stdout));
+
+    println!("\n--- Packet Statistics ---");
+    let stats_output = Command::new("netstat")
+        .arg("-i")
+        .output()
+        .expect("Failed to run 'netstat -i'");
+
+    if !stats_output.status.success() {
+        eprintln!("Error running 'netstat -i': {}", String::from_utf8_lossy(&stats_output.stderr));
+        return;
+    }
+    println!("{}", String::from_utf8_lossy(&stats_output.stdout));
+
+    println!("==================== End of Network Status ====================");
+
+    // tbh idk what 60% of the stuff here means, it just outputs some random junk but i think it makes sense.
+    // ¯\_(ツ)_/¯
+}
+
+fn network_restart() {
+    println!("Restarting networking services...");
+
+    let output = Command::new("sudo")
+        .arg("systemctl")
+        .arg("restart")
+        .arg("NetworkManager") // google said this is the one we should restart so ig it works? i didnt test it.
+        .output();
+
+    match output {
+        Ok(output) if output.status.success() => {
+            println!("Networking services restarted successfully.");
+        }
+        Ok(output) => {
+            eprintln!("Error restarting networking services: {}", String::from_utf8_lossy(&output.stderr));
+        }
+        Err(e) => {
+            eprintln!("Failed to execute command: {}", e);
+        }
+    }
+}
+
+fn network_test() {
+    // idk why i added this but the same info can be found in status
+    println!("==================== Network Diagnostics ====================");
+
+    println!("\n--- Internet Connectivity Test (ping) ---");
+    let ping_output = Command::new("ping")
+        .arg("-c")
+        .arg("4")
+        .arg("8.8.8.8")
+        .output();
+    
+    match ping_output {
+        Ok(output) if output.status.success() => {
+            println!("Ping successful! Internet is reachable.");
+        }
+        Ok(output) => {
+            eprintln!("Ping failed: {}", String::from_utf8_lossy(&output.stderr));
+        }
+        Err(e) => {
+            eprintln!("Error running ping: {}", e);
+        }
+    }
+
+    println!("\n--- Open Network Connections ---");
+    let ss_output = Command::new("ss")
+        .arg("-tuln")
+        .output();
+
+    match ss_output {
+        Ok(output) if output.status.success() => {
+            println!("{}", String::from_utf8_lossy(&output.stdout));
+        }
+        Ok(output) => {
+            eprintln!("Error checking open connections: {}", String::from_utf8_lossy(&output.stderr));
+        }
+        Err(e) => {
+            eprintln!("Error running ss: {}", e);
+        }
+    }
+
+    println!("==================== End of Network Diagnostics ====================");
+}

--- a/src/src/operations/networking.rs
+++ b/src/src/operations/networking.rs
@@ -1,6 +1,6 @@
 use crate::args::SimpleNetworking;
 use crate::args::NetworkOperation;
-use std::process::{Command, exit};
+use std::process::Command;
 
 pub fn networking(args: &SimpleNetworking) {
     match &args.action {


### PR DESCRIPTION
I added support for changing host name and viewing network info.

## Features

### Changing hostname
Run `axctl change-hostname <new-hostname>` or `axctl hostname <new-hostname>` to change the host name

### Networking info
- Added `axctl net status`
- Added `axctl net restart`
- Added `axctl net test`

| Networking sub command | Description | Use |
| --------------------------------- | ---------------- | ------ |
| status                              | Allows users to view complex information's about their internet in depth | Useful when you want to know information about their internet easily |
| restart                              | Restarts the internet service | Useful when you want to restart the internet easily |
| test                                   | Test's the users internet connectivity | Useful when you want to check your internet connection | 

> Info: The status sub command of net includes the same information that test prints.